### PR TITLE
fix Grafana agent version

### DIFF
--- a/local/docker-compose.yaml
+++ b/local/docker-compose.yaml
@@ -85,7 +85,7 @@ services:
       - "3000:3000"
 
   agent:
-    image: grafana/agent:latest
+    image: grafana/agent:v0.25.1
     volumes:
       # Agent configuration
       - ./config/agent.yaml:/etc/agent-config/agent.yaml


### PR DESCRIPTION
The latest Version of Grafana Agent container doesn't contain the /bin/agent file